### PR TITLE
Rename getVersions() to getFieldVersions(). Add getItemVersions() to ret...

### DIFF
--- a/src/Thybag/SharePointAPI.php
+++ b/src/Thybag/SharePointAPI.php
@@ -1029,6 +1029,7 @@ class SharePointAPI {
 
 	    return $results;
 	}
+    public function getColumnVersions ($list, $id, $field) { return $this->getFieldVersions($list, $id, $field); }
 	
 	/**
 	 * getItemVersions


### PR DESCRIPTION
...rieve the versions of an item as a whole instead of only a single field. Alias getVersions() to both depending on if  is passed
