### PR TITLE
SoapFault expects 2 parameters, this wasn't always given. Added curl_err...

### DIFF
--- a/src/Thybag/Auth/SharePointOnlineAuth.php
+++ b/src/Thybag/Auth/SharePointOnlineAuth.php
@@ -5,7 +5,7 @@ namespace Thybag\Auth;
  * SharePointOnlineAuth
  * Clone of the PHP SoapClient class, modified in order to allow transparent communication with
  * the SharePoint Online Web services.
- * 
+ *
  * @package Thybag\Auth
  */
 class SharePointOnlineAuth extends \SoapClient {
@@ -15,60 +15,60 @@ class SharePointOnlineAuth extends \SoapClient {
 
 	// Override do request method
 	public function __doRequest($request, $location, $action, $version, $one_way = false) {
-		
+
 		// Authenticate with SP online in order to get required authentication cookies
 		if (!$this->authCookies) $this->configureAuthCookies($location);
-		
+
 		// Set base headers
 		$headers = array();
 		$headers[] = "Content-Type: text/xml;";
 
-        $curl = curl_init($location);
+    $curl = curl_init($location);
 
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
-        curl_setopt($curl, CURLOPT_POST, TRUE);
+    curl_setopt($curl, CURLOPT_RETURNTRANSFER, TRUE);
+    curl_setopt($curl, CURLOPT_POST, TRUE);
 
-        // Send request and auth cookies.
-        curl_setopt($curl, CURLOPT_POSTFIELDS, $request);
-        curl_setopt($curl, CURLOPT_COOKIE, $this->authCookies); 
-     
-     	// Connection requires CURLOPT_SSLVERSION set to 3
-        curl_setopt($curl, CURLOPT_TIMEOUT, 10);
-        curl_setopt($curl, CURLOPT_SSLVERSION, 3);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
+    // Send request and auth cookies.
+    curl_setopt($curl, CURLOPT_POSTFIELDS, $request);
+    curl_setopt($curl, CURLOPT_COOKIE, $this->authCookies);
 
-        // Useful for debugging
-		curl_setopt($curl, CURLOPT_VERBOSE,FALSE);
-        curl_setopt($curl, CURLOPT_HEADER, FALSE);
-        
-        // SharePoint Online requires the SOAPAction header set for ADD/EDIT and DELETE Operations.
-        // Failure to have this will result in a "Security Validation exception"
-        // @see http://weblogs.asp.net/jan/archive/2009/05/25/quot-the-security-validation-for-this-page-is-invalid-quot-when-calling-the-sharepoint-web-services.aspx
-        if( strpos($request, 'UpdateListItems') !== FALSE ) {
-    		$headers[] =	'SOAPAction: "http://schemas.microsoft.com/sharepoint/soap/UpdateListItems"';
-        }
+ 	  // Connection requires CURLOPT_SSLVERSION set to 3
+    curl_setopt($curl, CURLOPT_TIMEOUT, 10);
+    curl_setopt($curl, CURLOPT_SSLVERSION, 3);
+    curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
 
-        // Add headers
-        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+    // Useful for debugging
+  	curl_setopt($curl, CURLOPT_VERBOSE,FALSE);
+    curl_setopt($curl, CURLOPT_HEADER, FALSE);
 
-        // Init the cURL
-        $response = curl_exec($curl);
-        
-        // Throw exceptions if there are any issues
-        if (curl_errno($curl)) throw new \SoapFault(curl_error($curl));
-		if ($response == '') throw new \SoapFault("No XML returned", "No XML returned");
-     
-		// Close CURL
-        curl_close($curl);
-        
-        // Return?
-        if (!$one_way) return ($response);
+    // SharePoint Online requires the SOAPAction header set for ADD/EDIT and DELETE Operations.
+    // Failure to have this will result in a "Security Validation exception"
+    // @see http://weblogs.asp.net/jan/archive/2009/05/25/quot-the-security-validation-for-this-page-is-invalid-quot-when-calling-the-sharepoint-web-services.aspx
+    if( strpos($request, 'UpdateListItems') !== FALSE ) {
+		  $headers[] =	'SOAPAction: "http://schemas.microsoft.com/sharepoint/soap/UpdateListItems"';
+    }
+
+    // Add headers
+    curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+
+    // Init the cURL
+    $response = curl_exec($curl);
+
+    // Throw exceptions if there are any issues
+    if (curl_errno($curl)) throw new \SoapFault(curl_errno($curl), curl_error($curl));
+    if ($response == '') throw new \SoapFault("No XML returned", "No XML returned");
+
+    // Close CURL
+    curl_close($curl);
+
+    // Return?
+    if (!$one_way) return ($response);
 	}
 
 	/**
 	 * ConfigureAuthCookies
 	 * Authenticate with sharepoint online in order to get valid authentication cookies
-	 * 
+	 *
 	 * @param $location - Url of sharepoint list
 	 *
 	 * More info on method:
@@ -112,11 +112,11 @@ class SharePointOnlineAuth extends \SoapClient {
 	 * extractAuthCookies
 	 * Extract Authentication cookies from SP response & format in to usable cookie string
 	 *
-	 * @param $result cURL Response 
+	 * @param $result cURL Response
 	 * @return $cookie_payload string containing cookie data.
 	 */
 	protected function extractAuthCookies($result){
-		
+
 	    $authCookies = array();
 	    $cookie_payload = '';
 
@@ -129,7 +129,7 @@ class SharePointOnlineAuth extends \SoapClient {
 	            $authCookies[] = $loop[1];
 	        }
 	    }
-	    unset($authCookies[0]); // No need for first cookie   
+	    unset($authCookies[0]); // No need for first cookie
 
 	    // Extract cookie name & payload and format in to cURL compatible string
 	    foreach($authCookies as $payload){
@@ -163,22 +163,22 @@ class SharePointOnlineAuth extends \SoapClient {
 		$ch = curl_init();
 	    curl_setopt($ch,CURLOPT_URL,$url);
 	    curl_setopt($ch,CURLOPT_POST,1);
-	    curl_setopt($ch,CURLOPT_POSTFIELDS,  $payload);   
+	    curl_setopt($ch,CURLOPT_POSTFIELDS,  $payload);
 	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-	  	
+
 	  	curl_setopt($ch, CURLOPT_SSLVERSION, 3);
 	    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 	    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
-	    
-	    if($header)  curl_setopt($ch, CURLOPT_HEADER, true); 
+
+	    if($header)  curl_setopt($ch, CURLOPT_HEADER, true);
 
 	    $result = curl_exec($ch);
 
 	    // catch error
 	    if($result === false) {
-	        throw new \SoapFault('Curl error: ' . curl_error($ch));
+	        throw new \SoapFault(curl_errno($ch), 'Curl error: ' . curl_error($ch));
 	    }
-	    
+
 	    curl_close($ch);
 
 	    return $result;
@@ -186,7 +186,7 @@ class SharePointOnlineAuth extends \SoapClient {
 
 	/**
 	 * Get the XML to request the security token
-	 * 
+	 *
 	 * @param string $username
 	 * @param string $password
 	 * @param string $endpoint


### PR DESCRIPTION
...no() in several cases. Fix a bit of spacing issues (IDE automatically did some of it (not the real purpose of this commit).
