### PR TITLE
Fixed Authorization header

### DIFF
--- a/src/Thybag/Auth/SoapClientAuth.php
+++ b/src/Thybag/Auth/SoapClientAuth.php
@@ -104,6 +104,7 @@ class SoapClientAuth extends \SoapClient {
 		curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
 
 		curl_setopt($ch, CURLOPT_USERPWD, $this->Username . ':' . $this->Password);
+		curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
 		curl_setopt($ch, CURLOPT_SSLVERSION, 3);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
 		curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);


### PR DESCRIPTION
The SOAP server would always return 401 to me, and after a morning of debugging I found that adding this line fixed the problem.
