### PR TITLE
Call loadXML with the LIBXML_PARSEHUGE option

### DIFF
--- a/src/Thybag/SharePointAPI.php
+++ b/src/Thybag/SharePointAPI.php
@@ -772,7 +772,7 @@ class SharePointAPI {
 	private function getArrayFromElementsByTagName ($rawXml, $tag, $namespace = NULL) {
 		// Get DOM instance and load XML
 		$dom = new \DOMDocument();
-		$dom->loadXML($rawXml);
+		$dom->loadXML($rawXml, (LIBXML_VERSION >= 20900) ? LIBXML_PARSEHUGE : null);
 
 		// Is namespace set?
 		if (!is_null($namespace)) {


### PR DESCRIPTION
Call loadXML with the LIBXML_PARSEHUGE option if running a version of DOMDocument that supports it.