### PR TITLE
php 8 support

### DIFF
--- a/src/Thybag/Auth/SoapClientAuth.php
+++ b/src/Thybag/Auth/SoapClientAuth.php
@@ -64,7 +64,7 @@ class SoapClientAuth extends \SoapClient {
 			\Thybag\Auth\StreamWrapperHttpAuth::$Password = $this->Password;
 		}
 
-		parent::SoapClient($wsdl, ($options ? $options : array()));
+		parent::__construct($wsdl, ($options ? $options : array()));
 
 		stream_wrapper_restore('http');
 		if (in_array("https", $wrappers)) stream_wrapper_restore('https');


### PR DESCRIPTION
Current version crashes on php 8.

See: https://github.com/notfalsedev/laravel-soap/pull/190