### PR TITLE
Bug-Fix: Call parent constructor of SoapClientAuth correctly.

### DIFF
--- a/src/Thybag/Auth/SoapClientAuth.php
+++ b/src/Thybag/Auth/SoapClientAuth.php
@@ -64,7 +64,7 @@ class SoapClientAuth extends \SoapClient {
 			\Thybag\Auth\StreamWrapperHttpAuth::$Password = $this->Password;
 		}
 
-		parent::SoapClient($wsdl, ($options ? $options : array()));
+		parent::__construct($wsdl, ($options ? $options : array()));
 
 		stream_wrapper_restore('http');
 		if (in_array("https", $wrappers)) stream_wrapper_restore('https');


### PR DESCRIPTION
The parent constructor call in SoapClientAuth on line 67 failed on PHP8. The correct call to the parent constructor with parent::__construct fixes the problem.